### PR TITLE
Moved `function_replacement_data_v2_t` to a private header.

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -1,7 +1,7 @@
 FROM ghcr.io/wiiu-env/devkitppc:20240505
 
 COPY --from=ghcr.io/wiiu-env/libkernel:20230621 /artifacts $DEVKITPRO
-COPY --from=ghcr.io/wiiu-env/libfunctionpatcher:20230621 /artifacts $DEVKITPRO
+COPY --from=ghcr.io/wiiu-env/libfunctionpatcher:20241012-5173f86 /artifacts $DEVKITPRO
 COPY --from=ghcr.io/wiiu-env/wiiumodulesystem:20240424 /artifacts $DEVKITPRO
 
 WORKDIR project

--- a/source/PatchedFunctionData.h
+++ b/source/PatchedFunctionData.h
@@ -1,5 +1,6 @@
 #pragma once
 
+#include "fpatching_defines_legacy.h"
 #include "FunctionAddressProvider.h"
 #include "PatchedFunctionData.h"
 #include "utils/logger.h"

--- a/source/PatchedFunctionData.h
+++ b/source/PatchedFunctionData.h
@@ -1,8 +1,8 @@
 #pragma once
 
-#include "fpatching_defines_legacy.h"
 #include "FunctionAddressProvider.h"
 #include "PatchedFunctionData.h"
+#include "fpatching_defines_legacy.h"
 #include "utils/logger.h"
 #include <coreinit/cache.h>
 #include <coreinit/debug.h>

--- a/source/fpatching_defines_legacy.h
+++ b/source/fpatching_defines_legacy.h
@@ -2,8 +2,8 @@
 
 /* Types that are kept only for ABI compatibility. */
 
-#include <stdint.h>
 #include <function_patcher/fpatching_defines.h>
+#include <stdint.h>
 
 typedef struct function_replacement_data_v2_t {
     uint32_t VERSION;

--- a/source/fpatching_defines_legacy.h
+++ b/source/fpatching_defines_legacy.h
@@ -1,0 +1,17 @@
+#pragma once
+
+/* Types that are kept only for ABI compatibility. */
+
+#include <stdint.h>
+#include <function_patcher/fpatching_defines.h>
+
+typedef struct function_replacement_data_v2_t {
+    uint32_t VERSION;
+    uint32_t physicalAddr;                       /* [needs to be filled]  */
+    uint32_t virtualAddr;                        /* [needs to be filled]  */
+    uint32_t replaceAddr;                        /* [needs to be filled] Address of our replacement function */
+    uint32_t *replaceCall;                       /* [needs to be filled] Address to access the real_function */
+    function_replacement_library_type_t library; /* [needs to be filled] rpl where the function we want to replace is. */
+    const char *function_name;                   /* [needs to be filled] name of the function we want to replace */
+    FunctionPatcherTargetProcess targetProcess;  /* [will be filled] */
+} function_replacement_data_v2_t;


### PR DESCRIPTION
This keeps the type in a private header, thus avoiding clashes with the `VERSION` identifier.